### PR TITLE
feat: implement entrance for chat room

### DIFF
--- a/src/main/java/com/sottie/sottiechat/controller/MessageController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/MessageController.java
@@ -1,0 +1,20 @@
+package com.sottie.sottiechat.controller;
+
+import com.sottie.sottiechat.dto.MessageRequest;
+import com.sottie.sottiechat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MessageController {
+    private final MessageService messageService;
+
+    @MessageMapping("chat.enter.{roomId}")
+    public void enterChatRoom(@DestinationVariable("roomId") Long roomId, @Payload MessageRequest.Enter message) {
+        messageService.enterChatRoom(roomId, message);
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
@@ -20,14 +20,16 @@ public class ChatMessage {
     private LocalDateTime timestamp;
     private MessageType messageType;
     private Status status;
+    private ChatType chatType;
 
     @Builder
-    public ChatMessage(Long chatRoomId, Long senderId, String content, MessageType messageType) {
+    public ChatMessage(Long chatRoomId, Long senderId, String content, MessageType messageType, LocalDateTime timestamp, Status status, ChatType chatType) {
         this.chatRoomId = chatRoomId;
         this.senderId = senderId;
         this.content = content;
         this.messageType = messageType;
-        this.timestamp = LocalDateTime.now();
-        this.status = Status.SUCCESS;
+        this.timestamp = timestamp;
+        this.status = status;
+        this.chatType = chatType;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/ChatType.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatType.java
@@ -1,0 +1,7 @@
+package com.sottie.sottiechat.domain;
+
+public enum ChatType {
+    ENTRANCE,
+    CHAT,
+    EXIT
+}

--- a/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
@@ -1,0 +1,30 @@
+package com.sottie.sottiechat.dto;
+
+import com.sottie.sottiechat.domain.ChatType;
+import com.sottie.sottiechat.domain.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MessageRequest {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Enter {
+        private UserInfo sender;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Chat {
+        private UserInfo sender;
+        private String contents;
+        private MessageType messageType;
+        private ChatType chatType;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
@@ -1,0 +1,25 @@
+package com.sottie.sottiechat.dto;
+
+import com.sottie.sottiechat.domain.ChatType;
+import com.sottie.sottiechat.domain.MessageType;
+import com.sottie.sottiechat.domain.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MessageResponse {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Chat {
+        private UserInfo sender;
+        private String contents;
+        private String timestamp;
+        private MessageType messageType;
+        private ChatType chatType;
+        private Status status;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/dto/UserInfo.java
+++ b/src/main/java/com/sottie/sottiechat/dto/UserInfo.java
@@ -1,0 +1,17 @@
+package com.sottie.sottiechat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserInfo {
+    private Long userId;
+    private String name;
+    private String nickname;
+    private String profileUrl;
+}

--- a/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
@@ -2,8 +2,14 @@ package com.sottie.sottiechat.repository;
 
 import com.sottie.sottiechat.domain.ChatMessage;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+
+    @Query("{'chatRoomId' : ?0, 'senderId' : ?1, 'chatType' : 'ENTRANCE'}")
+    List<ChatMessage> findByChatRoomIdAndSenderIdWithEntrance(Long chatRoomId, Long senderId);
 }

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -1,0 +1,74 @@
+package com.sottie.sottiechat.service;
+
+import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.domain.ChatType;
+import com.sottie.sottiechat.domain.MessageType;
+import com.sottie.sottiechat.domain.Status;
+import com.sottie.sottiechat.dto.MessageRequest;
+import com.sottie.sottiechat.dto.MessageResponse;
+import com.sottie.sottiechat.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final RabbitTemplate rabbitTemplate;
+    private static final String SUBSCRIBED_EXCHANGE_NAME = "sottie.chat.exchange";
+    private static final String ENTRANCE_ROUTING_KEY_PREFIX = "enter.room.";
+
+    public void enterChatRoom(Long roomId, MessageRequest.Enter request) {
+        if (isAlreadyEnteredChatRoom(roomId, request.getSender().getUserId())) {
+            log.error("채팅방 " + roomId + "에서" + "사용자" + request.getSender().getUserId() + "가 이미 입장함.");
+            throw new IllegalStateException("이미 채팅방에 입장한 사용자입니다.");
+        }
+
+        MessageResponse.Chat response = getEnterChatResponse(request);
+        Status status = Status.SUCCESS;
+        try {
+            sendMessageToSubscribers(roomId, response);
+        } catch (AmqpException e) {
+            status = Status.FAIL;
+        } finally {
+            chatMessageRepository.save(buildChatMessage(roomId, response, status));
+        }
+    }
+
+    private boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {
+        return !chatMessageRepository.findByChatRoomIdAndSenderIdWithEntrance(roomId, senderId).isEmpty();
+    }
+
+    private MessageResponse.Chat getEnterChatResponse(MessageRequest.Enter message) {
+        return MessageResponse.Chat.builder()
+                .sender(message.getSender())
+                .contents(message.getSender().getNickname() + "님이 채팅방에 참여했습니다.")
+                .messageType(MessageType.TEXT)
+                .chatType(ChatType.ENTRANCE)
+                .status(Status.SUCCESS)
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+    }
+
+    private ChatMessage buildChatMessage(Long roomId, MessageResponse.Chat response, Status status) {
+        return ChatMessage.builder()
+                .chatRoomId(roomId)
+                .senderId(response.getSender().getUserId())
+                .chatType(response.getChatType())
+                .messageType(response.getMessageType())
+                .timestamp(LocalDateTime.parse(response.getTimestamp()))
+                .status(status)
+                .content(response.getContents())
+                .build();
+    }
+
+    private void sendMessageToSubscribers(Long roomId, MessageResponse.Chat message) {
+        rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, ENTRANCE_ROUTING_KEY_PREFIX + roomId, message);
+    }
+}


### PR DESCRIPTION
- 채팅방 입장 기능 구현
  - 라우팅 키가 동일한 채팅방에 대하여 입장 요청에 대한 publish를 하는 경우
    1. 이미 입장했는지 MongoDB로부터 조회하여 검증
    2. 검증해서 데이터가 있다면 throw
    3. 검증해서 데이터가 없다면 해당 exchange에 subscribe하고 있는 유저들에게 메시지 전달
    4. 메시지를 MongoDB에 저장