### PR TITLE
feat: implement sending text message api

### DIFF
--- a/src/main/java/com/sottie/sottiechat/controller/MessageController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/MessageController.java
@@ -17,4 +17,9 @@ public class MessageController {
     public void enterChatRoom(@DestinationVariable("roomId") Long roomId, @Payload MessageRequest.Enter message) {
         messageService.enterChatRoom(roomId, message);
     }
+
+    @MessageMapping("chat.talk.{roomId}")
+    public void sendChatMessage(@DestinationVariable("roomId") Long roomId, @Payload MessageRequest.Chat message) {
+        messageService.sendChatMessage(roomId, message);
+    }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.sottie.sottiechat.domain;
 
+import com.sottie.sottiechat.dto.MessageResponse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,5 +32,17 @@ public class ChatMessage {
         this.timestamp = timestamp;
         this.status = status;
         this.chatType = chatType;
+    }
+
+    public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status){
+        return ChatMessage.builder()
+                .chatRoomId(roomId)
+                .senderId(response.getSender().getUserId())
+                .chatType(response.getChatType())
+                .messageType(response.getMessageType())
+                .timestamp(LocalDateTime.parse(response.getTimestamp()))
+                .status(status)
+                .content(response.getContents())
+                .build();
     }
 }

--- a/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class MessageResponse {
 
     @Data
@@ -21,5 +23,27 @@ public class MessageResponse {
         private MessageType messageType;
         private ChatType chatType;
         private Status status;
+
+        public static MessageResponse.Chat from(MessageRequest.Enter message) {
+            return MessageResponse.Chat.builder()
+                    .sender(message.getSender())
+                    .contents(message.getSender().getNickname() + "님이 채팅방에 참여했습니다.")
+                    .messageType(MessageType.TEXT)
+                    .chatType(ChatType.ENTRANCE)
+                    .status(Status.SUCCESS)
+                    .timestamp(LocalDateTime.now().toString())
+                    .build();
+        }
+
+        public static MessageResponse.Chat from(MessageRequest.Chat message) {
+            return Chat.builder()
+                    .sender(message.getSender())
+                    .contents(message.getContents())
+                    .messageType(MessageType.TEXT)
+                    .chatType(ChatType.CHAT)
+                    .status(Status.SUCCESS)
+                    .timestamp(LocalDateTime.now().toString())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -1,8 +1,6 @@
 package com.sottie.sottiechat.service;
 
 import com.sottie.sottiechat.domain.ChatMessage;
-import com.sottie.sottiechat.domain.ChatType;
-import com.sottie.sottiechat.domain.MessageType;
 import com.sottie.sottiechat.domain.Status;
 import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.dto.MessageResponse;
@@ -13,8 +11,6 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -22,7 +18,8 @@ public class MessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final RabbitTemplate rabbitTemplate;
     private static final String SUBSCRIBED_EXCHANGE_NAME = "sottie.chat.exchange";
-    private static final String ENTRANCE_ROUTING_KEY_PREFIX = "enter.room.";
+    private static final String ENTRANCE_ROUTING_KEY = "enter.room.";
+    private static final String CHAT_ROUTING_KEY = "*.room.";
 
     public void enterChatRoom(Long roomId, MessageRequest.Enter request) {
         if (isAlreadyEnteredChatRoom(roomId, request.getSender().getUserId())) {
@@ -30,45 +27,35 @@ public class MessageService {
             throw new IllegalStateException("이미 채팅방에 입장한 사용자입니다.");
         }
 
-        MessageResponse.Chat response = getEnterChatResponse(request);
+        MessageResponse.Chat response = MessageResponse.Chat.from(request);
+        sendMessageToSubs(roomId, response, ENTRANCE_ROUTING_KEY);
+    }
+
+    public void sendChatMessage(Long roomId, MessageRequest.Chat message) {
+        /*
+            TODO: 허용된 문자 & 형식 검사, 메시지 길이 제한, 도배 & 중복 방지(Rate Limit) -> 후순위
+             데이터 암호화 & NoSQL에 대한 SQL Injection 방지 -> 데이터 암호화는 중요할 수 있음
+         */
+        if (message.getContents().isBlank()) {
+            throw new IllegalStateException("빈 메시지를 전송할 수 없습니다.");
+        }
+        MessageResponse.Chat response = MessageResponse.Chat.from(message);
+        sendMessageToSubs(roomId, response, CHAT_ROUTING_KEY);
+    }
+
+    private void sendMessageToSubs(Long roomId, MessageResponse.Chat response, String routingKey) {
         Status status = Status.SUCCESS;
         try {
-            sendMessageToSubscribers(roomId, response);
+            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, response);
         } catch (AmqpException e) {
             status = Status.FAIL;
+            log.error("[{}] AMQP Protocol Exception (publish failure): {}", routingKey, e.getMessage());
         } finally {
-            chatMessageRepository.save(buildChatMessage(roomId, response, status));
+            chatMessageRepository.save(ChatMessage.from(roomId, response, status));
         }
     }
 
     private boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {
         return !chatMessageRepository.findByChatRoomIdAndSenderIdWithEntrance(roomId, senderId).isEmpty();
-    }
-
-    private MessageResponse.Chat getEnterChatResponse(MessageRequest.Enter message) {
-        return MessageResponse.Chat.builder()
-                .sender(message.getSender())
-                .contents(message.getSender().getNickname() + "님이 채팅방에 참여했습니다.")
-                .messageType(MessageType.TEXT)
-                .chatType(ChatType.ENTRANCE)
-                .status(Status.SUCCESS)
-                .timestamp(LocalDateTime.now().toString())
-                .build();
-    }
-
-    private ChatMessage buildChatMessage(Long roomId, MessageResponse.Chat response, Status status) {
-        return ChatMessage.builder()
-                .chatRoomId(roomId)
-                .senderId(response.getSender().getUserId())
-                .chatType(response.getChatType())
-                .messageType(response.getMessageType())
-                .timestamp(LocalDateTime.parse(response.getTimestamp()))
-                .status(status)
-                .content(response.getContents())
-                .build();
-    }
-
-    private void sendMessageToSubscribers(Long roomId, MessageResponse.Chat message) {
-        rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, ENTRANCE_ROUTING_KEY_PREFIX + roomId, message);
     }
 }


### PR DESCRIPTION
- 채팅 일반 텍스트 전송 API 구현
- 채팅 전송 상황에서의 고려상황 중 우선 '빈 메시지'만 처리
- 허용될 문자 및 형식 검사와 메시지 길이 제한, 도배 및 중복 방지에 대해서는 후순위 추후에 개발하기로 결정
- 데이터 암호화는 필요해보이나 리서치 결과, 서버에서 암호화하는 것이 아니라 클라이언트에서 E2EE를 처리해줘야한다고 한다.
  - 암호화, 복호화 모두 클라이언트에서 처리
  - 서버는 그저 암호화된 데이터를 받고, 전달해주는 역할