### PR TITLE
feat: implement retrieving latest chat simply

### DIFF
--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -1,0 +1,29 @@
+package com.sottie.sottiechat.controller;
+
+import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatApiController {
+    private final MessageService messageService;
+
+    @GetMapping("/api/chats/{chatRoomId}")
+    public ResponseEntity<List<ChatMessage>> getChatMessageByPaging(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @RequestParam("size") int size
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(messageService.getChatMessagesByPaging(chatRoomId, cursor, size));
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.sottie.sottiechat.repository;
 
 import com.sottie.sottiechat.domain.ChatMessage;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,4 +13,22 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 
     @Query("{'chatRoomId' : ?0, 'senderId' : ?1, 'chatType' : 'ENTRANCE'}")
     List<ChatMessage> findByChatRoomIdAndSenderIdWithEntrance(Long chatRoomId, Long senderId);
+
+    @Aggregation(
+            pipeline = {
+                    "{ $match : { 'chatRoomId' : ?0 } }",
+                    "{ $sort : { '_id' : -1 } }",
+                    "{ $limit : ?1 }"
+            }
+    )
+    List<ChatMessage> findLatestChat(Long chatRoomId, int limit);
+
+    @Aggregation(
+            pipeline = {
+                    "{ $match : { '_id' : { '$lt' : {'$oid' : ?1 } }, 'chatRoomId' : ?0 } }", // _id 비교는 ObjectId() 비교를 위해 $oid 사용
+                    "{ $sort : { '_id' : -1 } }",
+                    "{ $limit : ?2 }"
+            }
+    )
+    List<ChatMessage> findChatByPaging(Long chatRoomId, String lastId, int limit);
 }

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -11,6 +11,8 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -53,6 +55,16 @@ public class MessageService {
         } finally {
             chatMessageRepository.save(ChatMessage.from(roomId, response, status));
         }
+    }
+
+    public List<ChatMessage> getChatMessagesByPaging(Long chatRoomId, String cursor, int size) {
+        if (size < 1)
+            throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
+
+        if (cursor == null) // 최초 페이지
+            return chatMessageRepository.findLatestChat(chatRoomId, size);
+
+        return chatMessageRepository.findChatByPaging(chatRoomId, cursor, size);
     }
 
     private boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {


### PR DESCRIPTION
- MongoDB에서는 `@Aggregation` 어노테이션의 pipeline으로 쿼리문을 커스터마이징해서 작성할 수 있다고 합니다.
  - 가장 최근 내역은 `findLatestChat`으로 조회하며, 그 이후의 채팅 내역은 `findChatByPaging`을 통해 조회합니다.
  - 페이징은 Cursor Based Paging을 사용하였고 조회한 채팅 내역들 중에서 가장 마지막 데이터를 cursor로 요청하면 그 이후의 채팅 데이터를 조회하도록 합니다.
  - 조건은 입력 채팅방과 같으면서 id를 기준으로 내림차순하고 입력으로 받은 페이지 개수만큼만 쿼리해옵니다. (MongoDB에서의 ID 값은 해시 값의 유형이지만 순서를 가지고 있어 timestamp로도 조회 기준을 설정할 수 있지만 id로도 하였습니다.)

- `$oid`를 사용해야 MongoDB에서의 ID 값을 비교할 수 있습니다. (oid = ObjectId)