### PR TITLE
feat: implement managing read status in group chat

### DIFF
--- a/src/main/java/com/sottie/sottiechat/config/StompWebSocketConfig.java
+++ b/src/main/java/com/sottie/sottiechat/config/StompWebSocketConfig.java
@@ -1,15 +1,20 @@
 package com.sottie.sottiechat.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final WebSocketInterceptor interceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -22,5 +27,15 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setPathMatcher(new AntPathMatcher("."));
         registry.setApplicationDestinationPrefixes("/pub");
         registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+    }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.setMessageSizeLimit(128 * 1024); // 메시지 전송 크기 제한
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(interceptor);
     }
 }

--- a/src/main/java/com/sottie/sottiechat/config/WebSocketEventListener.java
+++ b/src/main/java/com/sottie/sottiechat/config/WebSocketEventListener.java
@@ -1,0 +1,43 @@
+package com.sottie.sottiechat.config;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+    채팅방 접속, 접속종료에 대한 접속자 세션 관리
+ */
+@Component
+public class WebSocketEventListener {
+    private final Map<String, String> connectedClients = new HashMap<>();
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        System.out.println("userId : " +accessor.getNativeHeader("userId"));
+        System.out.println("roomId : " +accessor.getNativeHeader("roomId"));
+        String username = accessor.getUser() != null ? accessor.getUser().getName() : "Unknown";
+
+        connectedClients.put(sessionId, username);
+        System.out.println("Connected: " + username + " (Session ID: " + sessionId + ")");
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+
+        String username = connectedClients.remove(sessionId);
+        System.out.println("Disconnected: " + username + " (Session ID: " + sessionId + ")");
+    }
+
+    public Map<String, String> getConnectedClients() {
+        return connectedClients;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/config/WebSocketInterceptor.java
+++ b/src/main/java/com/sottie/sottiechat/config/WebSocketInterceptor.java
@@ -1,0 +1,76 @@
+package com.sottie.sottiechat.config;
+
+import com.sottie.sottiechat.dto.MessageRequest;
+import com.sottie.sottiechat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketInterceptor implements ChannelInterceptor {
+    private final MessageService messageService;
+
+    @Override
+    public boolean preReceive(MessageChannel channel) {
+        return ChannelInterceptor.super.preReceive(channel);
+
+    }
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if (accessor.getCommand() != null) {
+            System.out.println(accessor.getCommand());
+            handleMessageByCommand(accessor.getCommand(), accessor);
+        }
+        // command가 null인 경우는 heart-beat 메시지 or 비-stomp 메시지
+        return message;
+    }
+
+    private void handleMessageByCommand(StompCommand command, StompHeaderAccessor accessor) {
+        switch (command) {
+            case CONNECT -> {
+                // TODO: 헤더에 JWT 인증된 유저에 대해 연결하기 (웹소켓 연결을 외부에서 한다면 보안적인 문제가 발생 가능성, 그래서 연결할 때도 인증이 필요)
+                //연결할 때는, 헤더 정보밖에 없어서 CONNECT 상태에서는 읽음 처리 x
+            }
+            case SUBSCRIBE -> {
+                // TODO: 헤더에 JWT 인증 정보 받아서 유저 정보 가져오기
+                Long roomId = parseRoomId(accessor); // sub destination에서 채팅방 id 추출
+
+                /* 임시처리 */
+                Long userId = 3L;
+                if (accessor.getFirstNativeHeader("userId") != null)
+                    userId = Long.parseLong(accessor.getFirstNativeHeader("userId"));
+                /* 임시처리 */
+                messageService.updateLastReadStatus(roomId, MessageRequest.LastRead.builder()
+                        .userId(userId)
+                        .messageId(null)
+                        .build()
+                );
+            }
+            case SEND -> {
+                // TODO: 헤더에 JWT 인증 정보 받아서 SEND한 유저 정보 가져오기
+                // TODO: 암호화?
+            }
+        }
+    }
+
+    private Long parseRoomId(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination != null) {
+            Matcher matcher = Pattern.compile(".*\\.(\\d+)$").matcher(destination);
+            if (matcher.matches()) {
+                return Long.parseLong(matcher.group(1));
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -1,14 +1,12 @@
 package com.sottie.sottiechat.controller;
 
-import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.domain.LastReadStatus;
+import com.sottie.sottiechat.dto.MessageResponse;
 import com.sottie.sottiechat.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,12 +16,20 @@ public class ChatApiController {
     private final MessageService messageService;
 
     @GetMapping("/api/chats/{chatRoomId}")
-    public ResponseEntity<List<ChatMessage>> getChatMessageByPaging(
+    public ResponseEntity<List<MessageResponse.Chat>> getChatMessageByPaging(
             @PathVariable("chatRoomId") Long chatRoomId,
             @RequestParam(value = "cursor", required = false) String cursor,
             @RequestParam("size") int size
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(messageService.getChatMessagesByPaging(chatRoomId, cursor, size));
+    }
+
+    @GetMapping("/api/chats/readStatus/{chatRoomId}")
+    public ResponseEntity<List<LastReadStatus>> getReadStatusByChatRoom(
+            @PathVariable("chatRoomId") Long chatRoomId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(messageService.getReadStatusByChatRoom(chatRoomId));
     }
 }

--- a/src/main/java/com/sottie/sottiechat/controller/MessageController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/MessageController.java
@@ -22,4 +22,10 @@ public class MessageController {
     public void sendChatMessage(@DestinationVariable("roomId") Long roomId, @Payload MessageRequest.Chat message) {
         messageService.sendChatMessage(roomId, message);
     }
+
+    // DB에 읽음 처리가 다 끝났을 때에 이벤트 처리
+    @MessageMapping("chat.read.{roomId}")
+    public void updateLastReadMessage(@DestinationVariable("roomId") Long roomId, @Payload MessageRequest.LastRead lastRead) {
+        messageService.updateLastReadStatus(roomId, lastRead);
+    }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
@@ -16,33 +16,37 @@ public class ChatMessage {
     @Id
     private String id;
     private Long chatRoomId;
-    private Long senderId;
-    private String content;
+    private Long userId;
+    private String contents;
     private LocalDateTime timestamp;
     private MessageType messageType;
     private Status status;
     private ChatType chatType;
 
     @Builder
-    public ChatMessage(Long chatRoomId, Long senderId, String content, MessageType messageType, LocalDateTime timestamp, Status status, ChatType chatType) {
+    public ChatMessage(Long chatRoomId, Long userId, String contents, MessageType messageType, LocalDateTime timestamp, Status status, ChatType chatType) {
         this.chatRoomId = chatRoomId;
-        this.senderId = senderId;
-        this.content = content;
+        this.userId = userId;
+        this.contents = contents;
         this.messageType = messageType;
         this.timestamp = timestamp;
         this.status = status;
         this.chatType = chatType;
     }
 
-    public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status){
+    public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status) {
         return ChatMessage.builder()
                 .chatRoomId(roomId)
-                .senderId(response.getSender().getUserId())
+                .userId(response.getUserId())
                 .chatType(response.getChatType())
                 .messageType(response.getMessageType())
-                .timestamp(LocalDateTime.parse(response.getTimestamp()))
+                .timestamp(LocalDateTime.now())
                 .status(status)
-                .content(response.getContents())
+                .contents(response.getContents())
                 .build();
+    }
+
+    public void updateStatus(Status status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/LastReadStatus.java
+++ b/src/main/java/com/sottie/sottiechat/domain/LastReadStatus.java
@@ -1,0 +1,29 @@
+package com.sottie.sottiechat.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document("last_read_status")
+@Getter
+@NoArgsConstructor
+public class LastReadStatus {
+    @Id
+    private String id;
+    private Long chatRoomId;
+    private Long userId;
+    private String messageId;
+    private LocalDateTime readTimestamp;
+
+    @Builder
+    public LastReadStatus(Long chatRoomId, Long userId, String messageId, LocalDateTime readTimestamp) {
+        this.chatRoomId = chatRoomId;
+        this.userId = userId;
+        this.messageId = messageId;
+        this.readTimestamp = readTimestamp;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/domain/SocketEvent.java
+++ b/src/main/java/com/sottie/sottiechat/domain/SocketEvent.java
@@ -1,0 +1,14 @@
+package com.sottie.sottiechat.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+   소켓 통신에 대한 이벤트 이름 정의
+ */
+@Getter
+@NoArgsConstructor
+public enum SocketEvent {
+    SEND_MESSAGE,
+    UPDATE_READ_STATUS
+}

--- a/src/main/java/com/sottie/sottiechat/dto/CommonResponse.java
+++ b/src/main/java/com/sottie/sottiechat/dto/CommonResponse.java
@@ -1,0 +1,17 @@
+package com.sottie.sottiechat.dto;
+
+import com.sottie.sottiechat.domain.SocketEvent;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CommonResponse<T> {
+    private SocketEvent event;
+    private T data;
+
+    public CommonResponse(SocketEvent event, T data) {
+        this.event = event;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
@@ -14,7 +14,7 @@ public class MessageRequest {
     @NoArgsConstructor
     @Builder
     public static class Enter {
-        private UserInfo sender;
+        private Long userId;
     }
 
     @Data
@@ -22,9 +22,18 @@ public class MessageRequest {
     @NoArgsConstructor
     @Builder
     public static class Chat {
-        private UserInfo sender;
+        private Long userId;
         private String contents;
         private MessageType messageType;
         private ChatType chatType;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class LastRead {
+        private Long userId;
+        private String messageId;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
@@ -17,17 +17,19 @@ public class MessageResponse {
     @NoArgsConstructor
     @Builder
     public static class Chat {
-        private UserInfo sender;
+        private Long userId;
+        private String messageId;
         private String contents;
         private String timestamp;
         private MessageType messageType;
         private ChatType chatType;
         private Status status;
 
-        public static MessageResponse.Chat from(MessageRequest.Enter message) {
-            return MessageResponse.Chat.builder()
-                    .sender(message.getSender())
-                    .contents(message.getSender().getNickname() + "님이 채팅방에 참여했습니다.")
+        public static MessageResponse.Chat from(MessageRequest.Enter enter) {
+            return Chat.builder()
+                    .userId(enter.getUserId())
+                    .messageId(null)
+                    .contents(enter.getUserId() + "님이 채팅방에 참여했습니다.") // TODO: Redis 캐시 또는 RDB로부터 유저 정보 제대로 조회해오기
                     .messageType(MessageType.TEXT)
                     .chatType(ChatType.ENTRANCE)
                     .status(Status.SUCCESS)
@@ -35,15 +37,30 @@ public class MessageResponse {
                     .build();
         }
 
-        public static MessageResponse.Chat from(MessageRequest.Chat message) {
+        public static MessageResponse.Chat from(MessageRequest.Chat chat) {
             return Chat.builder()
-                    .sender(message.getSender())
-                    .contents(message.getContents())
+                    .userId(chat.getUserId())
+                    .messageId(null)
+                    .contents(chat.getContents())
                     .messageType(MessageType.TEXT)
                     .chatType(ChatType.CHAT)
                     .status(Status.SUCCESS)
                     .timestamp(LocalDateTime.now().toString())
                     .build();
         }
+
+        public void updateMessageId(String messageId) {
+            this.messageId = messageId;
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class LastRead {
+        private Long userId;
+        private String lastReadMessageId;
+        private String readTimeStamp;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
@@ -22,6 +23,15 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
             }
     )
     List<ChatMessage> findLatestChat(Long chatRoomId, int limit);
+
+    @Aggregation(
+            pipeline = {
+                    "{ $match : { 'chatRoomId' : ?0, 'userId' : {'$ne' : ?1 } } }",
+                    "{ $sort : { '_id' : -1 } }",
+                    "{ $limit : 1 }"
+            }
+    )
+    Optional<ChatMessage> findLatestChatOthers(Long chatRoomId, Long userId);
 
     @Aggregation(
             pipeline = {

--- a/src/main/java/com/sottie/sottiechat/repository/LastReadStatusRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/LastReadStatusRepository.java
@@ -1,0 +1,9 @@
+package com.sottie.sottiechat.repository;
+
+import com.sottie.sottiechat.domain.LastReadStatus;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LastReadStatusRepository extends MongoRepository<LastReadStatus, String> {
+}

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -1,7 +1,9 @@
 package com.sottie.sottiechat.service;
 
 import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.domain.LastReadStatus;
 import com.sottie.sottiechat.domain.Status;
+import com.sottie.sottiechat.dto.CommonResponse;
 import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.dto.MessageResponse;
 import com.sottie.sottiechat.repository.ChatMessageRepository;
@@ -9,9 +11,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.sottie.sottiechat.domain.SocketEvent.*;
 
 @Service
 @RequiredArgsConstructor
@@ -19,13 +28,15 @@ import java.util.List;
 public class MessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final RabbitTemplate rabbitTemplate;
+    private final MongoTemplate mongoTemplate;
     private static final String SUBSCRIBED_EXCHANGE_NAME = "sottie.chat.exchange";
     private static final String ENTRANCE_ROUTING_KEY = "enter.room.";
     private static final String CHAT_ROUTING_KEY = "*.room.";
+    private static final String LAST_READ_ROUTING_KEY = "read.room.";
 
     public void enterChatRoom(Long roomId, MessageRequest.Enter request) {
-        if (isAlreadyEnteredChatRoom(roomId, request.getSender().getUserId())) {
-            log.error("채팅방 " + roomId + "에서" + "사용자" + request.getSender().getUserId() + "가 이미 입장함.");
+        if (isAlreadyEnteredChatRoom(roomId, request.getUserId())) {
+            log.error("채팅방 " + roomId + "에서" + "사용자" + request.getUserId() + "가 이미 입장함.");
             throw new IllegalStateException("이미 채팅방에 입장한 사용자입니다.");
         }
 
@@ -33,41 +44,116 @@ public class MessageService {
         sendMessageToSubs(roomId, response, ENTRANCE_ROUTING_KEY);
     }
 
-    public void sendChatMessage(Long roomId, MessageRequest.Chat message) {
+    public void sendChatMessage(Long roomId, MessageRequest.Chat request) {
         /*
             TODO: 허용된 문자 & 형식 검사, 메시지 길이 제한, 도배 & 중복 방지(Rate Limit) -> 후순위
              데이터 암호화 & NoSQL에 대한 SQL Injection 방지 -> 데이터 암호화는 중요할 수 있음
          */
-        if (message.getContents().isBlank()) {
+        if (request.getContents().isBlank()) {
             throw new IllegalStateException("빈 메시지를 전송할 수 없습니다.");
         }
-        MessageResponse.Chat response = MessageResponse.Chat.from(message);
+        MessageResponse.Chat response = MessageResponse.Chat.from(request);
         sendMessageToSubs(roomId, response, CHAT_ROUTING_KEY);
+    }
+
+    public void updateLastReadStatus(Long roomId, MessageRequest.LastRead lastRead) {
+        // 채팅방 접속하는 경우, 최신 채팅 조회
+        if (lastRead.getMessageId() == null) {
+            String latestChatId = getLatestChatId(roomId, lastRead.getUserId());
+            if (latestChatId == null)
+                return;
+            lastRead.setMessageId(latestChatId);
+        }
+
+        // DB에 읽음 상태 업데이트
+        if (!updateLastRead(roomId, lastRead.getMessageId(), lastRead.getUserId())) {
+            log.warn("읽음 처리 요청이 들어왔으나 요청 실패");
+            return;
+        }
+
+        // 읽음 상태 propagate
+        try {
+            MessageResponse.LastRead build = MessageResponse.LastRead.builder()
+                    .lastReadMessageId(lastRead.getMessageId())
+                    .readTimeStamp(LocalDateTime.now().toString())
+                    .userId(lastRead.getUserId()).build();
+            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, LAST_READ_ROUTING_KEY + roomId, new CommonResponse<>(UPDATE_READ_STATUS, build));
+        } catch (AmqpException e) {
+            log.error("[{}] AMQP Protocol Exception (propagation failure]): {}", LAST_READ_ROUTING_KEY, e.getMessage());
+        }
+    }
+
+    public List<LastReadStatus> getReadStatusByChatRoom(Long roomId) {
+        return mongoTemplate.find(new Query(Criteria.where("chatRoomId").is(roomId)), LastReadStatus.class);
     }
 
     private void sendMessageToSubs(Long roomId, MessageResponse.Chat response, String routingKey) {
         Status status = Status.SUCCESS;
+        // 저장하고 저장된 메시지 ID까지 함께 구독자들에게 전파
+        ChatMessage saved = null;
         try {
-            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, response);
+            saved = chatMessageRepository.save(ChatMessage.from(roomId, response, status));
+            response.updateMessageId(saved.getId());
+            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, new CommonResponse<>(SEND_MESSAGE, response));
         } catch (AmqpException e) {
             status = Status.FAIL;
+            if (saved != null) {
+                saved.updateStatus(status);
+                chatMessageRepository.save(saved);
+            }
             log.error("[{}] AMQP Protocol Exception (publish failure): {}", routingKey, e.getMessage());
-        } finally {
-            chatMessageRepository.save(ChatMessage.from(roomId, response, status));
         }
     }
 
-    public List<ChatMessage> getChatMessagesByPaging(Long chatRoomId, String cursor, int size) {
+    public List<MessageResponse.Chat> getChatMessagesByPaging(Long chatRoomId, String cursor, int size) {
         if (size < 1)
             throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
 
         if (cursor == null) // 최초 페이지
-            return chatMessageRepository.findLatestChat(chatRoomId, size);
+            return buildMessages(chatMessageRepository.findLatestChat(chatRoomId, size));
 
-        return chatMessageRepository.findChatByPaging(chatRoomId, cursor, size);
+        return buildMessages(chatMessageRepository.findChatByPaging(chatRoomId, cursor, size));
+    }
+
+    private List<MessageResponse.Chat> buildMessages(List<ChatMessage> chatMessages) {
+        return chatMessages.stream().map((c) -> MessageResponse.Chat.builder()
+                .messageId(c.getId())
+                .contents(c.getContents())
+                .userId(c.getUserId())
+                .timestamp(c.getTimestamp().toString())
+                .messageType(c.getMessageType())
+                .chatType(c.getChatType())
+                .status(c.getStatus()).build()).toList();
     }
 
     private boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {
         return !chatMessageRepository.findByChatRoomIdAndSenderIdWithEntrance(roomId, senderId).isEmpty();
+    }
+
+    private String getLatestChatId(Long roomId, Long userId) {
+        return chatMessageRepository.findLatestChatOthers(roomId, userId)
+                .map(ChatMessage::getId)
+                .orElse(null);
+    }
+
+    private boolean updateLastRead(Long chatRoomId, String messageId, Long userId) {
+        // 이미 읽은 처리된 메시지면 무시
+        if (mongoTemplate.exists(new Query(Criteria
+                        .where("chatRoomId").is(chatRoomId)
+                        .and("userId").is(userId)
+                        .and("messageId").is(messageId)),
+                LastReadStatus.class)) {
+            return false;
+        }
+        Query query = new Query(Criteria
+                .where("chatRoomId").is(chatRoomId)
+                .and("userId").is(userId));
+
+        Update update = new Update();
+        LocalDateTime now = LocalDateTime.now();
+        update.set("messageId", messageId);
+        update.set("readTimestamp", now);
+        return mongoTemplate.upsert(query, update, LastReadStatus.class)
+                .wasAcknowledged();
     }
 }

--- a/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
+++ b/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 class ChatMessageTest {
 
@@ -16,24 +14,24 @@ class ChatMessageTest {
     ChatMessageRepository chatMessageRepository;
 
     @AfterEach
-    void clean(){
+    void clean() {
         chatMessageRepository.deleteAll();
     }
 
     @Test
-    void insertionTest(){
+    void insertionTest() {
         ChatMessage message = ChatMessage.builder()
                 .chatRoomId(1L)
-                .senderId(2L)
-                .content("Hello World")
+                .userId(2L)
+                .contents("Hello World")
                 .messageType(MessageType.TEXT)
                 .build();
 
         ChatMessage saved = chatMessageRepository.save(message);
 
         ChatMessage chatMessage = chatMessageRepository.findById(saved.getId()).get();
-        Assertions.assertThat(chatMessage.getContent()).isEqualTo("Hello World");
-        Assertions.assertThat(chatMessage.getSenderId()).isEqualTo(2L);
+        Assertions.assertThat(chatMessage.getContents()).isEqualTo("Hello World");
+        Assertions.assertThat(chatMessage.getUserId()).isEqualTo(2L);
         Assertions.assertThat(chatMessage.getChatRoomId()).isEqualTo(1L);
         Assertions.assertThat(chatMessage.getMessageType()).isEqualTo(MessageType.TEXT);
         Assertions.assertThat(chatMessage.getStatus()).isEqualTo(Status.SUCCESS);


### PR DESCRIPTION
### 웹소켓 인터셉터 구현
- 채팅방에 접속하고 활동하고 접속이 끊기는 모든 상태에 대한 '라이프 사이클' 처리를 하기 위한 인터셉터를 구현.
  - STOMP 프로토콜 메시지를 전송할 때 command 값이 있는데, 이 값으로 라이프 사이클 정의 (connect -> subscribe -> send -> disconnect)
    - **Connect**: 채팅방 접속 시, 해당 유저가 인증된 유저인지 검증
    - **Subscribe**: 채팅방을 구독 시, 해당 유저의 정보를 가져오고 그 정보를 바탕으로 읽음 처리 수행
    - **Send**: 채팅 전송 시, 유저 인증 확인하고 유저 정보 가져오기, 암호화?
    - **Disconnect**: 미정
  - 유저 인증은 JWT 구현이 되면 적용 예정.
  - 특히, 구독의 경우 메시지 destination에서 채팅방 정보를 추출하여, 해당 채팅방에서 본인을 제외한 최신 채팅 내역에 읽음 처리 업데이트

### 읽음 처리 구현
- 해당 채팅방에서 각 유저가 마지막으로 읽은 메시지 ID 정보를 저장하도록 설계. (유저당 한개의 메시지 ID를 1:1 매핑)
- 메시지 ID가 null인 경우(= 채팅방 접속하는 순간): 최신 채팅 1개를 조회해서 해당 메시지의 ID로 적용
- 채팅방에 접속 중인 경우: 소켓으로 메시지 ID 전달받음
- 프로세스
  1. 해당 메시지를 이미 읽음 처리한 경우 무시
  2. 그렇지 않은 경우 해당 유저에 대해 메시지 ID로 업데이트(upsert)
  3. 업데이트 실패한 경우 Propagation 불가능 (1. 이미 업데이트된 경우, 2. 예기치 못한 상황으로 업데이트가 안되는 경우)
  4. 업데이트가 되면 해당 메시지를 읽었다는 내용으로 채팅방에 접속 중인 유저들에게 propagation 수행

- 핵심은 클라이언트 측이 될 것으로 추정. (서버 사이드에서 어떻게 처리하는게 옳은 것인지 모르겠다..)
  - 클라이언트는 처음에 채팅방 접속하면 최신 채팅 내역과 더불어 채팅방의 모든 유저의 마지막 읽음 상태 정보를 조회 (Rest API)
  - 소켓 통신 이벤트를 구분(메시지 전송, 읽음 상태 업데이트); 각 상태에 따라서
    - 메시지 전송이면 해당 채팅을 리스트에 추가
    - 읽음 상태 업데이트면 해당 유저의 읽음 상태 정보를 업데이트

### 이외.. 짜잘한 것
1. 소켓 통신에 대한 공통 응답 폼 정의와 더불어 소켓 통신에 대한 이벤트 이름 정의
2. 채팅 데이터에 대한 소켓 통신과 Rest API 응답 형식 통일

### 추가
- 읽음 처리의 경우 유저랑 메시지랑 1대1이기 때문에 이전의 읽은 기록은 사라지게 된다. 이에 대한 로깅(기록, 백업)이 필요할까?
- 각 클라이언트가 나머지 유저의 읽은 정보를 갖고 있는게 맞는걸까?
- 읽음 처리를 각 클라이언트가 수행하는게 아니라 서버 사이드에서 수행하는거는 옳지 아니한걸까?