### PR TITLE
feat: implement uploading media files in chat with propagating message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+	// aws
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/sottie/sottiechat/config/AwsS3Config.java
+++ b/src/main/java/com/sottie/sottiechat/config/AwsS3Config.java
@@ -1,0 +1,30 @@
+package com.sottie.sottiechat.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/config/StompConnectionListener.java
+++ b/src/main/java/com/sottie/sottiechat/config/StompConnectionListener.java
@@ -1,35 +1,47 @@
 package com.sottie.sottiechat.config;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /*
     채팅방 접속, 접속종료에 대한 접속자 세션 관리
  */
 @Component
-public class WebSocketEventListener {
-    private final Map<String, String> connectedClients = new HashMap<>();
+@Slf4j
+@RequiredArgsConstructor
+public class StompConnectionListener {
+    private final ConcurrentHashMap<String, String> connectedClients = new ConcurrentHashMap<>();
 
+    // TODO: Redis 같은 곳에서 분산해서 {사용자 ID : 세션 ID} key:value 구조로 관리
     @EventListener
-    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+    public void handleSessionConnected(SessionConnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = accessor.getSessionId();
         System.out.println("userId : " +accessor.getNativeHeader("userId"));
         System.out.println("roomId : " +accessor.getNativeHeader("roomId"));
         String username = accessor.getUser() != null ? accessor.getUser().getName() : "Unknown";
 
-        connectedClients.put(sessionId, username);
+        if(accessor.getNativeHeader("userId") != null) {
+            username = accessor.getNativeHeader("userId").get(0);
+        }
+//        if(connectedClients.containsValue(username)){
+//            log.warn("이미 접속 중인 유저: {}", username);
+//            throw new IllegalStateException("이미 채팅방에 접속 중입니다.");
+//        }
+        connectedClients.put(username, sessionId);
         System.out.println("Connected: " + username + " (Session ID: " + sessionId + ")");
     }
 
     @EventListener
-    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+    public void handleSessionDisconnected(SessionDisconnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = accessor.getSessionId();
 

--- a/src/main/java/com/sottie/sottiechat/config/WebSocketInterceptor.java
+++ b/src/main/java/com/sottie/sottiechat/config/WebSocketInterceptor.java
@@ -3,8 +3,10 @@ package com.sottie.sottiechat.config;
 import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.service.MessageService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -15,20 +17,23 @@ import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketInterceptor implements ChannelInterceptor {
     private final MessageService messageService;
 
     @Override
     public boolean preReceive(MessageChannel channel) {
         return ChannelInterceptor.super.preReceive(channel);
-
     }
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        SimpMessageType messageType = accessor.getMessageType();
+        log.info("[소켓 메시지 타입] {}", messageType);
+
         if (accessor.getCommand() != null) {
-            System.out.println(accessor.getCommand());
+            log.info("[WebSocket Access]: {}", accessor.getCommand());
             handleMessageByCommand(accessor.getCommand(), accessor);
         }
         // command가 null인 경우는 heart-beat 메시지 or 비-stomp 메시지
@@ -39,9 +44,10 @@ public class WebSocketInterceptor implements ChannelInterceptor {
         switch (command) {
             case CONNECT -> {
                 // TODO: 헤더에 JWT 인증된 유저에 대해 연결하기 (웹소켓 연결을 외부에서 한다면 보안적인 문제가 발생 가능성, 그래서 연결할 때도 인증이 필요)
+                // TODO: 해당 유저가 이 채팅방에 접속 가능한 유저인지 검증 (API 서버 통신)
                 //연결할 때는, 헤더 정보밖에 없어서 CONNECT 상태에서는 읽음 처리 x
             }
-            case SUBSCRIBE -> {
+            case SUBSCRIBE -> { // 해당 채팅방 접속
                 // TODO: 헤더에 JWT 인증 정보 받아서 유저 정보 가져오기
                 Long roomId = parseRoomId(accessor); // sub destination에서 채팅방 id 추출
 
@@ -49,16 +55,23 @@ public class WebSocketInterceptor implements ChannelInterceptor {
                 Long userId = 3L;
                 if (accessor.getFirstNativeHeader("userId") != null)
                     userId = Long.parseLong(accessor.getFirstNativeHeader("userId"));
-                /* 임시처리 */
+
+                // 최초 입장 처리
+                messageService.enterChatRoom(roomId, MessageRequest.Enter.builder()
+                        .userId(userId)
+                        .build());
+
+                // 읽음 처리
                 messageService.updateLastReadStatus(roomId, MessageRequest.LastRead.builder()
                         .userId(userId)
-                        .messageId(null)
-                        .build()
-                );
+                        .build());
             }
             case SEND -> {
                 // TODO: 헤더에 JWT 인증 정보 받아서 SEND한 유저 정보 가져오기
                 // TODO: 암호화?
+            }
+            case DISCONNECT -> {
+                // TODO: 세션 삭제
             }
         }
     }

--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -2,11 +2,13 @@ package com.sottie.sottiechat.controller;
 
 import com.sottie.sottiechat.domain.LastReadStatus;
 import com.sottie.sottiechat.dto.MessageResponse;
+import com.sottie.sottiechat.service.MediaService;
 import com.sottie.sottiechat.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -14,22 +16,33 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatApiController {
     private final MessageService messageService;
+    private final MediaService mediaService;
 
-    @GetMapping("/api/chats/{chatRoomId}")
+    @GetMapping("/api/chat/{roomId}")
     public ResponseEntity<List<MessageResponse.Chat>> getChatMessageByPaging(
-            @PathVariable("chatRoomId") Long chatRoomId,
+            @PathVariable("roomId") Long roomId,
             @RequestParam(value = "cursor", required = false) String cursor,
             @RequestParam("size") int size
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(messageService.getChatMessagesByPaging(chatRoomId, cursor, size));
+                .body(messageService.getChatMessagesByPaging(roomId, cursor, size));
     }
 
-    @GetMapping("/api/chats/readStatus/{chatRoomId}")
+    @GetMapping("/api/chat/{roomId}/readStatus")
     public ResponseEntity<List<LastReadStatus>> getReadStatusByChatRoom(
-            @PathVariable("chatRoomId") Long chatRoomId
+            @PathVariable("roomId") Long roomId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(messageService.getReadStatusByChatRoom(chatRoomId));
+                .body(messageService.getReadStatusByChatRoom(roomId));
+    }
+
+    @PostMapping(value = "/api/chat/{roomId}/media/{userId}", consumes = {"multipart/form-data"})
+    public ResponseEntity<Void> uploadMediaFile(
+            @PathVariable("roomId") Long roomId,
+            @PathVariable("userId") Long userId, // TODO: JWT 헤더로 변경
+            @RequestPart(value = "files") List<MultipartFile> files
+    ) {
+        mediaService.uploadMediaFiles(roomId, userId, files);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/MediaType.java
+++ b/src/main/java/com/sottie/sottiechat/domain/MediaType.java
@@ -1,0 +1,5 @@
+package com.sottie.sottiechat.domain;
+
+public enum MediaType {
+    PHOTO, VIDEO
+}

--- a/src/main/java/com/sottie/sottiechat/domain/SocketEvent.java
+++ b/src/main/java/com/sottie/sottiechat/domain/SocketEvent.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public enum SocketEvent {
-    SEND_MESSAGE,
-    UPDATE_READ_STATUS
+    INITIAL_ENTRANCE, // 채팅방 최초 입장
+    SEND_MESSAGE, // 메시지 전송
+    UPDATE_READ_STATUS // 읽음 상태 업데이트
 }

--- a/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageResponse.java
@@ -42,7 +42,7 @@ public class MessageResponse {
                     .userId(chat.getUserId())
                     .messageId(null)
                     .contents(chat.getContents())
-                    .messageType(MessageType.TEXT)
+                    .messageType(chat.getMessageType())
                     .chatType(ChatType.CHAT)
                     .status(Status.SUCCESS)
                     .timestamp(LocalDateTime.now().toString())

--- a/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
-    @Query("{'chatRoomId' : ?0, 'senderId' : ?1, 'chatType' : 'ENTRANCE'}")
+    @Query("{'chatRoomId' : ?0, 'userId' : ?1, 'chatType' : 'ENTRANCE'}")
     List<ChatMessage> findByChatRoomIdAndSenderIdWithEntrance(Long chatRoomId, Long senderId);
 
     @Aggregation(

--- a/src/main/java/com/sottie/sottiechat/service/MediaService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MediaService.java
@@ -1,0 +1,90 @@
+package com.sottie.sottiechat.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.sottie.sottiechat.domain.MediaType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MediaService {
+    private final AmazonS3Client amazonS3Client;
+    private final MessageService messageService;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    private static final List<String> ALLOWED_PHOTO_EXTENSION = List.of("jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff");
+    private static final List<String> ALLOWED_VIDEO_EXTENSION = List.of("mp4", "mpg", "mpeg", "mov", "vob");
+    private static final int MAX_MEDIA_LIMIT_AMOUNT = 10;
+    private static final String CHAT_ROOT_PATH = "static/chat/";
+    private static final String PHOTO_BUCKET_PATH = "/photos/";
+    private static final String VIDEO_BUCKET_PATH = "/videos/";
+
+    public void uploadMediaFiles(Long roomId, Long userId, List<MultipartFile> files) {
+        if (amazonS3Client == null)
+            throw new IllegalStateException("AWS 연결 실패");
+        if (bucket == null)
+            throw new IllegalStateException("유효하지 않은 버킷");
+
+        if (files.isEmpty() || files.size() > MAX_MEDIA_LIMIT_AMOUNT)
+            throw new IllegalArgumentException("유효하지 않은 파일의 개수");
+
+        for (MultipartFile file : files) {
+            if (file.getOriginalFilename() == null)
+                return;
+            String extension = extractExt(file.getOriginalFilename().toLowerCase());
+            MediaType mediaType = findMediaTypeByExt(extension)
+                    .orElseThrow(() -> new IllegalStateException("유효하지 않은 미디어 형식"));
+
+            String mediaPath;
+            if (mediaType == MediaType.PHOTO) {
+                mediaPath = CHAT_ROOT_PATH + roomId + PHOTO_BUCKET_PATH + generateUniqueName(extension);
+            } else {
+                mediaPath = CHAT_ROOT_PATH + roomId + VIDEO_BUCKET_PATH + generateUniqueName(extension);
+            }
+
+            // TODO: File Compression
+            try {
+                amazonS3Client.putObject(bucket, mediaPath, file.getInputStream(), getMetadata(file));
+                String url = amazonS3Client.getUrl(bucket, mediaPath).toString();
+                messageService.sendMediaMessage(roomId, userId, url);
+            } catch (Exception e) {
+                log.error("채팅 미디어 파일 저장 error : {}", e.getMessage());
+            }
+        }
+    }
+
+    private ObjectMetadata getMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+        return metadata;
+    }
+
+    private Optional<MediaType> findMediaTypeByExt(String ext) {
+        if (ext == null)
+            return Optional.empty();
+        if (ALLOWED_VIDEO_EXTENSION.contains(ext))
+            return Optional.of(MediaType.VIDEO);
+        if (ALLOWED_PHOTO_EXTENSION.contains(ext))
+            return Optional.of(MediaType.PHOTO);
+
+        return Optional.empty();
+    }
+
+    private String generateUniqueName(String ext) {
+        return UUID.randomUUID() + "." + ext;
+    }
+
+    private String extractExt(String fileName) {
+        return fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -1,8 +1,6 @@
 package com.sottie.sottiechat.service;
 
-import com.sottie.sottiechat.domain.ChatMessage;
-import com.sottie.sottiechat.domain.LastReadStatus;
-import com.sottie.sottiechat.domain.Status;
+import com.sottie.sottiechat.domain.*;
 import com.sottie.sottiechat.dto.CommonResponse;
 import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.dto.MessageResponse;
@@ -35,25 +33,39 @@ public class MessageService {
     private static final String LAST_READ_ROUTING_KEY = "read.room.";
 
     public void enterChatRoom(Long roomId, MessageRequest.Enter request) {
+        log.info("[채팅방 {}번] 사용자 {} 접속", roomId, request.getUserId());
         if (isAlreadyEnteredChatRoom(roomId, request.getUserId())) {
-            log.error("채팅방 " + roomId + "에서" + "사용자" + request.getUserId() + "가 이미 입장함.");
-            throw new IllegalStateException("이미 채팅방에 입장한 사용자입니다.");
+            return;
         }
-
         MessageResponse.Chat response = MessageResponse.Chat.from(request);
-        sendMessageToSubs(roomId, response, ENTRANCE_ROUTING_KEY);
+        sendMessageToSubs(roomId, response, ENTRANCE_ROUTING_KEY, INITIAL_ENTRANCE);
     }
 
     public void sendChatMessage(Long roomId, MessageRequest.Chat request) {
-        /*
-            TODO: 허용된 문자 & 형식 검사, 메시지 길이 제한, 도배 & 중복 방지(Rate Limit) -> 후순위
-             데이터 암호화 & NoSQL에 대한 SQL Injection 방지 -> 데이터 암호화는 중요할 수 있음
-         */
         if (request.getContents().isBlank()) {
             throw new IllegalStateException("빈 메시지를 전송할 수 없습니다.");
         }
         MessageResponse.Chat response = MessageResponse.Chat.from(request);
-        sendMessageToSubs(roomId, response, CHAT_ROUTING_KEY);
+        sendMessageToSubs(roomId, response, CHAT_ROUTING_KEY, SEND_MESSAGE);
+    }
+
+    public void sendMediaMessage(Long roomId, Long userId, String mediaUrl) {
+        sendMessageToSubs(roomId, MessageResponse.Chat.from(MessageRequest.Chat.builder()
+                .messageType(getMessageTypeByUrl(mediaUrl))
+                .chatType(ChatType.CHAT)
+                .contents(mediaUrl)
+                .userId(userId)
+                .build()), CHAT_ROUTING_KEY, SEND_MESSAGE);
+    }
+
+    private MessageType getMessageTypeByUrl(String mediaUrl) {
+        if (mediaUrl.contains("photos"))
+            return MessageType.IMAGE;
+        if (mediaUrl.contains("videos"))
+            return MessageType.VIDEO;
+        if (mediaUrl.contains("files"))
+            return MessageType.FILE;
+        return MessageType.TEXT;
     }
 
     public void updateLastReadStatus(Long roomId, MessageRequest.LastRead lastRead) {
@@ -64,10 +76,17 @@ public class MessageService {
                 return;
             lastRead.setMessageId(latestChatId);
         }
+        ChatMessage message = chatMessageRepository.findById(lastRead.getMessageId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
+
+        // 일반 채팅이 아닌 경우 읽음 처리 무시
+        if (message.getChatType() != ChatType.CHAT) {
+            log.warn("[메시지 읽음 처리]: ChatType이 CHAT이 아님");
+            return;
+        }
 
         // DB에 읽음 상태 업데이트
         if (!updateLastRead(roomId, lastRead.getMessageId(), lastRead.getUserId())) {
-            log.warn("읽음 처리 요청이 들어왔으나 요청 실패");
+            log.warn("[메시지 읽음 처리]: DB에 상태 업데이트 실패");
             return;
         }
 
@@ -87,14 +106,14 @@ public class MessageService {
         return mongoTemplate.find(new Query(Criteria.where("chatRoomId").is(roomId)), LastReadStatus.class);
     }
 
-    private void sendMessageToSubs(Long roomId, MessageResponse.Chat response, String routingKey) {
+    private void sendMessageToSubs(Long roomId, MessageResponse.Chat response, String routingKey, SocketEvent event) {
         Status status = Status.SUCCESS;
         // 저장하고 저장된 메시지 ID까지 함께 구독자들에게 전파
         ChatMessage saved = null;
         try {
             saved = chatMessageRepository.save(ChatMessage.from(roomId, response, status));
             response.updateMessageId(saved.getId());
-            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, new CommonResponse<>(SEND_MESSAGE, response));
+            rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, new CommonResponse<>(event, response));
         } catch (AmqpException e) {
             status = Status.FAIL;
             if (saved != null) {
@@ -105,14 +124,15 @@ public class MessageService {
         }
     }
 
-    public List<MessageResponse.Chat> getChatMessagesByPaging(Long chatRoomId, String cursor, int size) {
+    public List<MessageResponse.Chat> getChatMessagesByPaging(Long roomId, String cursor, int size) {
         if (size < 1)
             throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
 
+        // TODO: 일별로 response 정렬하기
         if (cursor == null) // 최초 페이지
-            return buildMessages(chatMessageRepository.findLatestChat(chatRoomId, size));
+            return buildMessages(chatMessageRepository.findLatestChat(roomId, size));
 
-        return buildMessages(chatMessageRepository.findChatByPaging(chatRoomId, cursor, size));
+        return buildMessages(chatMessageRepository.findChatByPaging(roomId, cursor, size));
     }
 
     private List<MessageResponse.Chat> buildMessages(List<ChatMessage> chatMessages) {
@@ -136,17 +156,18 @@ public class MessageService {
                 .orElse(null);
     }
 
-    private boolean updateLastRead(Long chatRoomId, String messageId, Long userId) {
+    private boolean updateLastRead(Long roomId, String messageId, Long userId) {
         // 이미 읽은 처리된 메시지면 무시
         if (mongoTemplate.exists(new Query(Criteria
-                        .where("chatRoomId").is(chatRoomId)
+                        .where("chatRoomId").is(roomId)
                         .and("userId").is(userId)
                         .and("messageId").is(messageId)),
                 LastReadStatus.class)) {
+            log.warn("[메시지 읽음 처리]: 이미 읽은 메시지");
             return false;
         }
         Query query = new Query(Criteria
-                .where("chatRoomId").is(chatRoomId)
+                .where("chatRoomId").is(roomId)
                 .and("userId").is(userId));
 
         Update update = new Update();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,26 @@ spring:
     mongodb:
       uri: mongodb://localhost:27017
       database: sottie-chat
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 200MB
+
+server:
+  compression:
+    enabled: true
+    mime-types: text/html,text/plain,text/css,application/javascript,application/json, application/zip, application/octet-stream
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret_key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+


### PR DESCRIPTION
## 1. Naming 통일
- Controller의 PathVariable 이름, 메소드의 parameter 이름 등 일관성 없던 문제를 네이밍 통일화 (chatRoomId -> roomId)
- 추가적으로 API의 URI 중에 경로 이름 변경 (chats -> chat)

## 2. 채팅 입장 처리 변경
### AS-IS
- 기존 클라이언트에서 직접 입장 처리에 대한 publish 요청하게끔 구현함. 
- 즉, 수동처리했기 때문에 중간 과정 하나라도 동작을 올바르게 하지 않는다면 입장처리에 대해 문제가 발생할거라고 느낌
### TO-BE
- WebSocket의 Interceptor의 Command에 따른 처리에서 채팅방에 접속하는 순간 (SUBSCRIBE) 메시지 입장처리하게끔 수정.
- 입장처리는 채팅방 '최초 입장'인 경우 최초 입장 메시지를 브로커를 통해 publish하고 메시지를 DB에 저장.
  - 매번 접속할 때마다 호출이 되지만, "publish하고 저장하는 것"은 이미 입장한 적이 있는지 검증을 하여 있다면 무시하게끔 구현함.
  - 현재는 접속하는 것에 대한 로깅을 찍어두었지만 채팅방 자체에 접속했을 때 무언가를 처리해야한다면 여기에 새롭게 추가할 수 있을 것임.
- '최초 입장'에 대한 소켓 이벤트도 별도로 정의.

## 3. 읽음 처리 로직 추가
- 최초 입장 메시지가 오면 그 메시지마저 읽음 처리해야할까? 에 대한 의문점에서 시작한다.
- 그거까지는 아닌 것 같다는 결론으로 '채팅의 유형'이 **입장 또는 퇴장**이 아닌 '채팅'인 경우에만 읽음 처리가 가능하게끔 중간 검증 로직을 하나 추가.

## 4. 브로커 Publish
- 브로커를 통해 메시지를 propagation하는 메소드에서 parameter로 '소켓 이벤트'를 입력받아 유연하게 응답을 전달하게끔 변경

## 5. 미디어 파일 메시지 전송 구현
- 미디어 스토리지인 AWS S3에 업로드하기 위한 Configuration 추가.
- 파일 업로드 요청 즉, Multipart 요청으로 받기 위해 REST API로 요청하고, 브로커를 통해 메시지를 propagation하는 형식으로 구현.
- 파일이 비거나 현재 정의한 최대 개수(10개)를 초과하는 경우 throw 처리.
- 파일 List를 순회하면서 각 파일의 형식이 이미지 또는 영상이 맞는지 검증하고, 랜덤 파일 이름과 함께 이미지면 이미지, 영상이면 영상에 맞게끔 저장 경로가 지정되고 S3의 그 경로로 파일이 업로드 요청을 하게 구현.
- 각 파일마다 업로드가 되면 그 경로에 대해서 미디어 파일 전용 메시지가 생성되어 브로커를 통해 메시지를 전송.
- 파일 여러개 중 일부가 실패했을 경우 처리는 성공한 파일은 보내고, 실패한 파일은 무시하게끔 처리할 것이다. (현재는 검증에 실패하면 throw를 했기 때문에 다른 처리로 바꿔야할 듯)
  - 추가로 Global Exception 핸들링도 추가해야할 듯하다.
- AWS의 CloudFront도 배포 완료 (CDN) -> S3 URL에 대해 direct access 불가

### TODO
- 채팅방 중복접속 방지 기능 구현 (접속 핸들러로 세션과 유저에 대한 key:value 생성)
- 해당 유저가 해당 채팅방에 접속 가능한지 권한 검증
- 채팅방 상태에 대한 로깅?
- Heartbeat 문제