### PR TITLE
feat: implement encrypting chat contents with encoding & decoding

### DIFF
--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -3,7 +3,7 @@ package com.sottie.sottiechat.controller;
 import com.sottie.sottiechat.domain.LastReadStatus;
 import com.sottie.sottiechat.dto.MessageResponse;
 import com.sottie.sottiechat.service.MediaService;
-import com.sottie.sottiechat.service.MessageService;
+import com.sottie.sottiechat.service.MessageQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 public class ChatApiController {
-    private final MessageService messageService;
+    private final MessageQueryService messageQueryService;
     private final MediaService mediaService;
 
     @GetMapping("/api/chat/{roomId}")
@@ -25,7 +25,7 @@ public class ChatApiController {
             @RequestParam("size") int size
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(messageService.getChatMessagesByPaging(roomId, cursor, size));
+                .body(messageQueryService.getChatMessagesByPaging(roomId, cursor, size));
     }
 
     @GetMapping("/api/chat/{roomId}/readStatus")
@@ -33,7 +33,7 @@ public class ChatApiController {
             @PathVariable("roomId") Long roomId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(messageService.getReadStatusByChatRoom(roomId));
+                .body(messageQueryService.getReadStatusByChatRoom(roomId));
     }
 
     @PostMapping(value = "/api/chat/{roomId}/media/{userId}", consumes = {"multipart/form-data"})

--- a/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
@@ -34,7 +34,7 @@ public class ChatMessage {
         this.chatType = chatType;
     }
 
-    public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status) {
+    public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status, String encodedContents) {
         return ChatMessage.builder()
                 .chatRoomId(roomId)
                 .userId(response.getUserId())
@@ -42,7 +42,7 @@ public class ChatMessage {
                 .messageType(response.getMessageType())
                 .timestamp(LocalDateTime.now())
                 .status(status)
-                .contents(response.getContents())
+                .contents(encodedContents)
                 .build();
     }
 

--- a/src/main/java/com/sottie/sottiechat/service/CryptoService.java
+++ b/src/main/java/com/sottie/sottiechat/service/CryptoService.java
@@ -1,0 +1,58 @@
+package com.sottie.sottiechat.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+// TODO: AES 암호화 원리 및 이론 숙지
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CryptoService {
+
+    @Value("${aes.secret-key}")
+    private String key;
+    private IvParameterSpec ivParameterSpec;
+    private SecretKeySpec secretKeySpec;
+    private Cipher cipher;
+
+    @PostConstruct
+    public void init() throws NoSuchPaddingException, NoSuchAlgorithmException {
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        secretKeySpec = new SecretKeySpec(keyBytes, "AES");
+        ivParameterSpec = new IvParameterSpec(keyBytes);
+        cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    }
+
+    public String encodeAES(String plainText) {
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] encryptionByte = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+            return new String(Base64.getEncoder().encode(encryptionByte), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.warn("CryptoService: 암호화 실패", e.getMessage());
+            throw new IllegalStateException("메시지 암호화에 실패했습니다.");
+        }
+    }
+
+    public String decodeAES(String encodedText) {
+        try {
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] decodeByte = Base64.getDecoder().decode(encodedText.getBytes(StandardCharsets.UTF_8));
+            return new String(cipher.doFinal(decodeByte), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.warn("CryptoService: 복호화 실패", e.getMessage());
+            throw new IllegalArgumentException("메시지 복호화에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/service/MessageQueryService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageQueryService.java
@@ -1,0 +1,64 @@
+package com.sottie.sottiechat.service;
+
+import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.domain.LastReadStatus;
+import com.sottie.sottiechat.dto.MessageResponse;
+import com.sottie.sottiechat.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageQueryService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final CryptoService cryptoService;
+    private final MongoTemplate mongoTemplate;
+
+    public ChatMessage getMessage(String messageId) {
+        return chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
+    }
+
+    public List<MessageResponse.Chat> getChatMessagesByPaging(Long roomId, String cursor, int size) {
+        if (size < 1)
+            throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
+
+        // TODO: 일별로 response 정렬하기
+        if (cursor == null) // 최초 페이지
+            return buildMessages(chatMessageRepository.findLatestChat(roomId, size));
+
+        return buildMessages(chatMessageRepository.findChatByPaging(roomId, cursor, size));
+    }
+
+    private List<MessageResponse.Chat> buildMessages(List<ChatMessage> chatMessages) {
+        return chatMessages.stream().map((c) -> MessageResponse.Chat.builder()
+                .messageId(c.getId())
+                .contents(cryptoService.decodeAES(c.getContents()))
+                .userId(c.getUserId())
+                .timestamp(c.getTimestamp().toString())
+                .messageType(c.getMessageType())
+                .chatType(c.getChatType())
+                .status(c.getStatus()).build()).toList();
+    }
+
+    public List<LastReadStatus> getReadStatusByChatRoom(Long roomId) {
+        return mongoTemplate.find(new Query(Criteria.where("chatRoomId").is(roomId)), LastReadStatus.class);
+    }
+
+    public String getLatestChatId(Long roomId, Long userId) {
+        return chatMessageRepository.findLatestChatOthers(roomId, userId)
+                .map(ChatMessage::getId)
+                .orElse(null);
+    }
+
+    public boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {
+        return !chatMessageRepository.findByChatRoomIdAndSenderIdWithEntrance(roomId, senderId).isEmpty();
+    }
+}

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -16,7 +16,6 @@ import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static com.sottie.sottiechat.domain.SocketEvent.*;
 
@@ -25,6 +24,8 @@ import static com.sottie.sottiechat.domain.SocketEvent.*;
 @Slf4j
 public class MessageService {
     private final ChatMessageRepository chatMessageRepository;
+    private final MessageQueryService messageQueryService;
+    private final CryptoService cryptoService;
     private final RabbitTemplate rabbitTemplate;
     private final MongoTemplate mongoTemplate;
     private static final String SUBSCRIBED_EXCHANGE_NAME = "sottie.chat.exchange";
@@ -34,7 +35,7 @@ public class MessageService {
 
     public void enterChatRoom(Long roomId, MessageRequest.Enter request) {
         log.info("[채팅방 {}번] 사용자 {} 접속", roomId, request.getUserId());
-        if (isAlreadyEnteredChatRoom(roomId, request.getUserId())) {
+        if (messageQueryService.isAlreadyEnteredChatRoom(roomId, request.getUserId())) {
             return;
         }
         MessageResponse.Chat response = MessageResponse.Chat.from(request);
@@ -71,13 +72,12 @@ public class MessageService {
     public void updateLastReadStatus(Long roomId, MessageRequest.LastRead lastRead) {
         // 채팅방 접속하는 경우, 최신 채팅 조회
         if (lastRead.getMessageId() == null) {
-            String latestChatId = getLatestChatId(roomId, lastRead.getUserId());
+            String latestChatId = messageQueryService.getLatestChatId(roomId, lastRead.getUserId());
             if (latestChatId == null)
                 return;
             lastRead.setMessageId(latestChatId);
         }
-        ChatMessage message = chatMessageRepository.findById(lastRead.getMessageId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
-
+        ChatMessage message = messageQueryService.getMessage(lastRead.getMessageId());
         // 일반 채팅이 아닌 경우 읽음 처리 무시
         if (message.getChatType() != ChatType.CHAT) {
             log.warn("[메시지 읽음 처리]: ChatType이 CHAT이 아님");
@@ -102,16 +102,13 @@ public class MessageService {
         }
     }
 
-    public List<LastReadStatus> getReadStatusByChatRoom(Long roomId) {
-        return mongoTemplate.find(new Query(Criteria.where("chatRoomId").is(roomId)), LastReadStatus.class);
-    }
-
     private void sendMessageToSubs(Long roomId, MessageResponse.Chat response, String routingKey, SocketEvent event) {
         Status status = Status.SUCCESS;
         // 저장하고 저장된 메시지 ID까지 함께 구독자들에게 전파
         ChatMessage saved = null;
         try {
-            saved = chatMessageRepository.save(ChatMessage.from(roomId, response, status));
+            String encoded = cryptoService.encodeAES(response.getContents());
+            saved = chatMessageRepository.save(ChatMessage.from(roomId, response, status, encoded));
             response.updateMessageId(saved.getId());
             rabbitTemplate.convertAndSend(SUBSCRIBED_EXCHANGE_NAME, routingKey + roomId, new CommonResponse<>(event, response));
         } catch (AmqpException e) {
@@ -122,38 +119,6 @@ public class MessageService {
             }
             log.error("[{}] AMQP Protocol Exception (publish failure): {}", routingKey, e.getMessage());
         }
-    }
-
-    public List<MessageResponse.Chat> getChatMessagesByPaging(Long roomId, String cursor, int size) {
-        if (size < 1)
-            throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
-
-        // TODO: 일별로 response 정렬하기
-        if (cursor == null) // 최초 페이지
-            return buildMessages(chatMessageRepository.findLatestChat(roomId, size));
-
-        return buildMessages(chatMessageRepository.findChatByPaging(roomId, cursor, size));
-    }
-
-    private List<MessageResponse.Chat> buildMessages(List<ChatMessage> chatMessages) {
-        return chatMessages.stream().map((c) -> MessageResponse.Chat.builder()
-                .messageId(c.getId())
-                .contents(c.getContents())
-                .userId(c.getUserId())
-                .timestamp(c.getTimestamp().toString())
-                .messageType(c.getMessageType())
-                .chatType(c.getChatType())
-                .status(c.getStatus()).build()).toList();
-    }
-
-    private boolean isAlreadyEnteredChatRoom(Long roomId, Long senderId) {
-        return !chatMessageRepository.findByChatRoomIdAndSenderIdWithEntrance(roomId, senderId).isEmpty();
-    }
-
-    private String getLatestChatId(Long roomId, Long userId) {
-        return chatMessageRepository.findLatestChatOthers(roomId, userId)
-                .map(ChatMessage::getId)
-                .orElse(null);
     }
 
     private boolean updateLastRead(Long roomId, String messageId, Long userId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,10 +25,12 @@ cloud:
       bucket: ${S3_BUCKET_NAME}
     credentials:
       access-key: ${AWS_ACCESS_KEY}
-      secret_key: ${AWS_SECRET_KEY}
+      secret-key: ${AWS_SECRET_KEY}
     region:
       static: ${AWS_REGION}
       auto: false
     stack:
       auto: false
 
+aes:
+  secret-key: ${AES_SECRET_KEY}


### PR DESCRIPTION
## AES 암호화 적용
채팅 내역을 암호화해서 저장하고, 이를 클라이언트에게 채팅 내역을 보여줘야하기에 암호화뿐만 아니라 복호화도 가능한 것이 필요.
그 중 AES 암호화라는 것이 있어서 secret key를 적용하여 서버에서 암호화 및 복호화를 수행함.
- 채팅을 전송하는 기능, 즉 채팅 데이터를 저장할 때 암호화 수행
- 채팅 내역을 조회할 때는 복호화 수행

## 채팅 서비스 분리
- 조회용 서비스와 커맨드용 서비스를 분리