### PR TITLE
config: re-config with modifying codes for setting ec2 with docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:17-jdk-slim
+FROM openjdk:17-alpine
 
-COPY target/sottie-chat.jar app.jar
+COPY /build/libs/sottiechat-0.0.1-SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/java/com/sottie/sottiechat/config/RabbitConfig.java
+++ b/src/main/java/com/sottie/sottiechat/config/RabbitConfig.java
@@ -8,6 +8,7 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -45,7 +46,7 @@ public class RabbitConfig {
     @Bean
     public ConnectionFactory connectionFactory() {
         CachingConnectionFactory factory = new CachingConnectionFactory();
-        factory.setHost(properties.getHostName());
+        factory.setHost(properties.getHost());
         factory.setPort(properties.getPort());
         factory.setUsername(properties.getUsername());
         factory.setPassword(properties.getPassword());
@@ -63,6 +64,15 @@ public class RabbitConfig {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory());
         rabbitTemplate.setMessageConverter(jsonMessageConverter());
         return rabbitTemplate;
+    }
+    @Bean
+    public RabbitAdmin rabbitAdmin(ConnectionFactory connectionFactory){
+        RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+        admin.setAutoStartup(true);
+        admin.declareExchange(exchange());
+        admin.declareQueue(queue());
+        admin.declareBinding(binding(queue(), exchange()));
+        return admin;
     }
 }
 

--- a/src/main/java/com/sottie/sottiechat/config/RabbitConfigProperties.java
+++ b/src/main/java/com/sottie/sottiechat/config/RabbitConfigProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties("spring.rabbitmq")
 public class RabbitConfigProperties {
-    private String hostName;
+    private String host;
     private int port;
     private String username;
     private String password;

--- a/src/main/java/com/sottie/sottiechat/config/StompWebSocketConfig.java
+++ b/src/main/java/com/sottie/sottiechat/config/StompWebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.sottie.sottiechat.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -13,8 +14,11 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
+@EnableConfigurationProperties(RabbitConfigProperties.class)
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final WebSocketInterceptor interceptor;
+    private final RabbitConfigProperties properties;
+    private static final int STOMP_PORT = 61613;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -27,6 +31,13 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setPathMatcher(new AntPathMatcher("."));
         registry.setApplicationDestinationPrefixes("/pub");
         registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
+                .setRelayHost(properties.getHost())
+                .setRelayPort(STOMP_PORT)
+                .setSystemLogin(properties.getUsername())
+                .setSystemPasscode(properties.getPassword())
+                .setClientLogin(properties.getUsername())
+                .setClientPasscode(properties.getPassword())
+                .setVirtualHost("/")
                 .setSystemHeartbeatSendInterval(30000) // Heartbeat 전송 주기
                 .setSystemHeartbeatReceiveInterval(30000); // Heartbeat 수신 주기
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,6 @@ spring:
   data:
     mongodb:
       uri: ${DATASOURCE_URL}
-      database: sottie-chat
   servlet:
     multipart:
       max-file-size: 100MB


### PR DESCRIPTION
## AWS EC2에 Docker Compose로 환경설정을 위한 수정
- Spring Boot & MongoDB & RabbitMQ를 Docker Compose로 묶어서 실행

1. Dockerfile 수정
가볍고 배포에 유용한 alpine jdk로 변경
빌드된 .jar 파일 경로 재설정

2. RabbitConfigProperties 수정
application.yml의 설정된 이름과 변수 이름이 매핑되는건데 이런 실수를... hostName이 아니라 host...
이거 때문에 계속 host가 null 값으로 나왔던 것

3. RabbitConfig 수정
Exchange와 Queue가 자동으로 생성되도록 RabbitAdmin을 Bean으로 등록 후, 지정한 Exchange/Queue/Binding을 정의

4. Broker에 대한 설정
STOMP 프로토콜을 통한 외부 브로커 연결을 위한 Relay 설정 추가 (Spring Boot -> RabbitMQ 접속 위함)

5. MongoDB application.yml의 database 삭제
uri에 포함하여 설정하도록 변경