### PR TITLE
feat: 채팅 목록 조회 구조 개선

### DIFF
--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -1,7 +1,7 @@
 package com.sottie.sottiechat.controller;
 
 import com.sottie.sottiechat.domain.LastReadStatus;
-import com.sottie.sottiechat.dto.MessageResponse;
+import com.sottie.sottiechat.dto.ChatMessageDateGroup;
 import com.sottie.sottiechat.service.MediaService;
 import com.sottie.sottiechat.service.MessageQueryService;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +19,13 @@ public class ChatApiController {
     private final MediaService mediaService;
 
     @GetMapping("/api/chat/{roomId}")
-    public ResponseEntity<List<MessageResponse.Chat>> getChatMessageByPaging(
+    public ResponseEntity<List<ChatMessageDateGroup>> getChatMessageByPaging(
             @PathVariable("roomId") Long roomId,
             @RequestParam(value = "cursor", required = false) String cursor,
-            @RequestParam("size") int size
+            @RequestParam(value = "userId") Long userId // 조회 대상자, TODO: 토큰 헤더로 변경
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(messageQueryService.getChatMessagesByPaging(roomId, cursor, size));
+                .body(messageQueryService.getChatMessagesByPaging(userId, roomId, cursor, true));
     }
 
     @GetMapping("/api/chat/{roomId}/readStatus")

--- a/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatMessage.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class ChatMessage {
     @Id
     private String id;
-    private Long chatRoomId;
+    private Long roomId;
     private Long userId;
     private String contents;
     private LocalDateTime timestamp;
@@ -24,8 +24,8 @@ public class ChatMessage {
     private ChatType chatType;
 
     @Builder
-    public ChatMessage(Long chatRoomId, Long userId, String contents, MessageType messageType, LocalDateTime timestamp, Status status, ChatType chatType) {
-        this.chatRoomId = chatRoomId;
+    public ChatMessage(Long roomId, Long userId, String contents, MessageType messageType, LocalDateTime timestamp, Status status, ChatType chatType) {
+        this.roomId = roomId;
         this.userId = userId;
         this.contents = contents;
         this.messageType = messageType;
@@ -36,7 +36,7 @@ public class ChatMessage {
 
     public static ChatMessage from(Long roomId, MessageResponse.Chat response, Status status, String encodedContents) {
         return ChatMessage.builder()
-                .chatRoomId(roomId)
+                .roomId(roomId)
                 .userId(response.getUserId())
                 .chatType(response.getChatType())
                 .messageType(response.getMessageType())
@@ -48,5 +48,9 @@ public class ChatMessage {
 
     public void updateStatus(Status status) {
         this.status = status;
+    }
+
+    public void updateContents(String newContents) {
+        this.contents = newContents;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/ChatType.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ChatType.java
@@ -1,5 +1,8 @@
 package com.sottie.sottiechat.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum ChatType {
     ENTRANCE,
     CHAT,

--- a/src/main/java/com/sottie/sottiechat/domain/MessageType.java
+++ b/src/main/java/com/sottie/sottiechat/domain/MessageType.java
@@ -1,5 +1,8 @@
 package com.sottie.sottiechat.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum MessageType {
     TEXT,
     IMAGE,

--- a/src/main/java/com/sottie/sottiechat/domain/Status.java
+++ b/src/main/java/com/sottie/sottiechat/domain/Status.java
@@ -1,5 +1,8 @@
 package com.sottie.sottiechat.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum Status {
     SUCCESS,
     FAIL,

--- a/src/main/java/com/sottie/sottiechat/dto/ChatMessageDateGroup.java
+++ b/src/main/java/com/sottie/sottiechat/dto/ChatMessageDateGroup.java
@@ -1,0 +1,16 @@
+package com.sottie.sottiechat.dto;
+
+import com.sottie.sottiechat.domain.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessageDateGroup {
+    private String date;
+    private List<ChatMessage> chats;
+}

--- a/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/sottie/sottiechat/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.sottie.sottiechat.repository;
 
 import com.sottie.sottiechat.domain.ChatMessage;
+import com.sottie.sottiechat.dto.ChatMessageDateGroup;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
@@ -12,33 +13,71 @@ import java.util.Optional;
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
-    @Query("{'chatRoomId' : ?0, 'userId' : ?1, 'chatType' : 'ENTRANCE'}")
-    List<ChatMessage> findByChatRoomIdAndSenderIdWithEntrance(Long chatRoomId, Long senderId);
+    @Query("{'roomId' : ?0, 'userId' : ?1, 'chatType' : 'ENTRANCE'}")
+    List<ChatMessage> findByChatRoomIdAndSenderIdWithEntrance(Long roomId, Long senderId);
 
     @Aggregation(
             pipeline = {
-                    "{ $match : { 'chatRoomId' : ?0 } }",
-                    "{ $sort : { '_id' : -1 } }",
-                    "{ $limit : ?1 }"
-            }
-    )
-    List<ChatMessage> findLatestChat(Long chatRoomId, int limit);
-
-    @Aggregation(
-            pipeline = {
-                    "{ $match : { 'chatRoomId' : ?0, 'userId' : {'$ne' : ?1 } } }",
-                    "{ $sort : { '_id' : -1 } }",
-                    "{ $limit : 1 }"
-            }
-    )
-    Optional<ChatMessage> findLatestChatOthers(Long chatRoomId, Long userId);
-
-    @Aggregation(
-            pipeline = {
-                    "{ $match : { '_id' : { '$lt' : {'$oid' : ?1 } }, 'chatRoomId' : ?0 } }", // _id 비교는 ObjectId() 비교를 위해 $oid 사용
+                    "{ $match : { 'roomId' : ?1, " +
+                            "$or : [ {'userId' : ?0 }, {'userId' : { $ne : ?0 }, 'status' : 'SUCCESS' } ]" +
+                            " } }",
                     "{ $sort : { '_id' : -1 } }",
                     "{ $limit : ?2 }"
             }
     )
-    List<ChatMessage> findChatByPaging(Long chatRoomId, String lastId, int limit);
+    List<ChatMessage> findLatestChat(Long userId, Long roomId, int limit); // 최초 채팅 목록 조회
+
+    @Aggregation(
+            pipeline = {
+                    "{ $match : { 'roomId' : ?0, 'userId' : {'$ne' : ?1 } } }",
+                    "{ $sort : { '_id' : -1 } }",
+                    "{ $limit : 1 }"
+            }
+    )
+    Optional<ChatMessage> findLatestChatOthers(Long roomId, Long userId);
+
+    @Aggregation(
+            pipeline = {
+                    "{ $match : { '_id' : { '$lt' : {'$oid' : ?2 } }, 'roomId' : ?1, " + // _id 비교는 ObjectId() 비교를 위해 $oid 사용
+                            "$or: [ {'userId' : ?0 }, {'userId' : { $ne : ?0 }, 'status' : 'SUCCESS' } ]" +
+                            " } }",
+                    "{ $sort : { '_id' : -1 } }",
+                    "{ $limit : ?3 }"
+            }
+    )
+    List<ChatMessage> findChatByPaging(Long userId, Long roomId, String lastId, int limit);
+
+    @Aggregation(pipeline = {
+            // 조건에 대해 필터링한 데이터를 조회
+            "{ $match : { '_id' : { '$lt' : {'$oid' : ?2 } }, 'roomId' : ?1, " +
+                    "$or: [ {'userId' : ?0 }, {'userId' : { $ne : ?0 }, 'status' : 'SUCCESS' } ]" +
+                    " } }",
+            // 먼저 시간순으로 내림차순 정렬
+            "{ $sort: { 'timestamp': -1 } }",
+            // Y-m-d 포맷으로 timestamp 필드에 대한 날짜로 그룹핑해서 documents들을 리스트로 수집
+            "{ $group: { '_id': { '$dateToString': { 'format': '%Y-%m-%d', 'date': '$timestamp' } }, 'chats': { '$push': '$$ROOT' } } }",
+            // 최종 결과에서 _id 필드를 date필드로 변환
+            "{ $project: { '_id': 0, 'date': '$_id', 'chats': 1 } }", // _id 필드를 제외(0)하고, _id 필드 값을 date 필드로 변경, chats 필드는 포함하겠다는 의미
+            // 그룹화된 날짜 자체도 내림차순 정렬
+            "{ $sort: { 'date': -1 } }",
+            "{ $limit : ?3 }"
+    })
+    List<ChatMessageDateGroup> findChatByPagingGroupByDate(Long userId, Long roomId, String lastId, int limit);
+
+    @Aggregation(pipeline = {
+            // 조건에 대해 필터링한 데이터를 조회
+            "{ $match : { 'roomId' : ?1, " +
+                    "$or: [ {'userId' : ?0 }, {'userId' : { $ne : ?0 }, 'status' : 'SUCCESS' } ]" +
+                    " } }",
+            // 먼저 시간순으로 내림차순 정렬
+            "{ $sort: { 'timestamp': -1 } }",
+            // Y-m-d 포맷으로 timestamp 필드에 대한 날짜로 그룹핑해서 documents들을 리스트로 수집
+            "{ $group: { '_id': { '$dateToString': { 'format': '%Y-%m-%d', 'date': '$timestamp' } }, 'chats': { '$push': '$$ROOT' } } }",
+            // 최종 결과에서 _id 필드를 date필드로 변환
+            "{ $project: { '_id': 0, 'date': '$_id', 'chats': 1 } }",
+            // 그룹핑된 날짜 자체도 내림차순 정렬
+            "{ $sort: { 'date': -1 } }",
+            "{ $limit : ?2 }"
+    })
+    List<ChatMessageDateGroup> findLatestChatByPagingGroupByDate(Long userId, Long roomId, int limit);
 }

--- a/src/main/java/com/sottie/sottiechat/service/MessageQueryService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageQueryService.java
@@ -2,7 +2,7 @@ package com.sottie.sottiechat.service;
 
 import com.sottie.sottiechat.domain.ChatMessage;
 import com.sottie.sottiechat.domain.LastReadStatus;
-import com.sottie.sottiechat.dto.MessageResponse;
+import com.sottie.sottiechat.dto.ChatMessageDateGroup;
 import com.sottie.sottiechat.repository.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,32 +20,26 @@ public class MessageQueryService {
     private final ChatMessageRepository chatMessageRepository;
     private final CryptoService cryptoService;
     private final MongoTemplate mongoTemplate;
+    private static final int CURRENT_PAGING_SIZE = 30;
 
     public ChatMessage getMessage(String messageId) {
         return chatMessageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
     }
 
-    public List<MessageResponse.Chat> getChatMessagesByPaging(Long roomId, String cursor, int size) {
-        if (size < 1)
-            throw new IllegalArgumentException("페이지 개수가 유효하지 않습니다.");
+    public List<ChatMessageDateGroup> getChatMessagesByPaging(Long userId, Long roomId, String cursor, boolean useDecode) {
+        if (cursor == null) // 최신 채팅 조회
+            return buildMessages(chatMessageRepository.findLatestChatByPagingGroupByDate(userId, roomId, CURRENT_PAGING_SIZE), useDecode);
 
-        // TODO: 일별로 response 정렬하기
-        if (cursor == null) // 최초 페이지
-            return buildMessages(chatMessageRepository.findLatestChat(roomId, size));
-
-        return buildMessages(chatMessageRepository.findChatByPaging(roomId, cursor, size));
+        return buildMessages(chatMessageRepository.findChatByPagingGroupByDate(userId, roomId, cursor, CURRENT_PAGING_SIZE), useDecode);
     }
 
-    private List<MessageResponse.Chat> buildMessages(List<ChatMessage> chatMessages) {
-        return chatMessages.stream().map((c) -> MessageResponse.Chat.builder()
-                .messageId(c.getId())
-                .contents(cryptoService.decodeAES(c.getContents()))
-                .userId(c.getUserId())
-                .timestamp(c.getTimestamp().toString())
-                .messageType(c.getMessageType())
-                .chatType(c.getChatType())
-                .status(c.getStatus()).build()).toList();
+    private List<ChatMessageDateGroup> buildMessages(List<ChatMessageDateGroup> chatMessages, boolean useDecode) {
+        chatMessages.stream()
+                .flatMap(dateGroup -> dateGroup.getChats().stream())
+                .filter(chatMessage -> useDecode)
+                .forEach(chatMessage -> chatMessage.updateContents(cryptoService.decodeAES(chatMessage.getContents())));
+        return chatMessages;
     }
 
     public List<LastReadStatus> getReadStatusByChatRoom(Long roomId) {

--- a/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
+++ b/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
@@ -1,17 +1,25 @@
 package com.sottie.sottiechat.domain;
 
+import com.sottie.sottiechat.dto.ChatMessageDateGroup;
+import com.sottie.sottiechat.dto.MessageResponse;
 import com.sottie.sottiechat.repository.ChatMessageRepository;
+import com.sottie.sottiechat.service.MessageQueryService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @SpringBootTest
 class ChatMessageTest {
 
     @Autowired
     ChatMessageRepository chatMessageRepository;
+    @Autowired
+    MessageQueryService messageQueryService;
 
     @AfterEach
     void clean() {
@@ -21,7 +29,7 @@ class ChatMessageTest {
     @Test
     void insertionTest() {
         ChatMessage message = ChatMessage.builder()
-                .chatRoomId(1L)
+                .roomId(1L)
                 .userId(2L)
                 .contents("Hello World")
                 .messageType(MessageType.TEXT)
@@ -32,11 +40,77 @@ class ChatMessageTest {
         ChatMessage chatMessage = chatMessageRepository.findById(saved.getId()).get();
         Assertions.assertThat(chatMessage.getContents()).isEqualTo("Hello World");
         Assertions.assertThat(chatMessage.getUserId()).isEqualTo(2L);
-        Assertions.assertThat(chatMessage.getChatRoomId()).isEqualTo(1L);
+        Assertions.assertThat(chatMessage.getRoomId()).isEqualTo(1L);
         Assertions.assertThat(chatMessage.getMessageType()).isEqualTo(MessageType.TEXT);
         Assertions.assertThat(chatMessage.getStatus()).isEqualTo(Status.SUCCESS);
         System.out.println(chatMessage.getTimestamp());
         System.out.println(chatMessage.getId());
+    }
 
+    @Test
+    void getFailureChat(){
+        ChatMessage message = ChatMessage.builder()
+                .roomId(1L)
+                .userId(1L)
+                .contents("Hello World")
+                .messageType(MessageType.TEXT)
+                .chatType(ChatType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 26, 14, 0))
+                .status(Status.FAIL)
+                .build();
+        ChatMessage message4 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(1L)
+                .contents("Hello World4")
+                .messageType(MessageType.TEXT)
+                .chatType(ChatType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 25, 14, 0))
+                .status(Status.SUCCESS)
+                .build();
+        ChatMessage message2 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(2L)
+                .contents("Hello World2")
+                .messageType(MessageType.TEXT)
+                .chatType(ChatType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 26, 14, 2))
+                .status(Status.SUCCESS)
+                .build();
+        ChatMessage message3 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(2L)
+                .contents("Hello World3")
+                .messageType(MessageType.TEXT)
+                .chatType(ChatType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 27, 14, 0))
+                .status(Status.FAIL)
+                .build();
+        ChatMessage message5 = ChatMessage.builder()
+                .roomId(2L)
+                .userId(3L)
+                .contents("Hello World5")
+                .chatType(ChatType.CHAT)
+                .messageType(MessageType.TEXT)
+                .timestamp(LocalDateTime.of(2025, 3, 27, 14, 1))
+                .status(Status.FAIL)
+                .build();
+
+        ChatMessage saved = chatMessageRepository.save(message);
+        ChatMessage saved2 = chatMessageRepository.save(message2);
+        ChatMessage saved3 = chatMessageRepository.save(message3);
+        ChatMessage saved4 = chatMessageRepository.save(message4);
+        ChatMessage saved5 = chatMessageRepository.save(message5);
+        // 5개 중 message3, 5 빼고 다 나와야됨
+        List<ChatMessageDateGroup> paging = messageQueryService.getChatMessagesByPaging(1L, 1L, saved3.getId(), false);
+
+//        Assertions.assertThat(paging.size()).isEqualTo(3);
+
+
+        List<ChatMessageDateGroup> groupByDate = chatMessageRepository.findChatByPagingGroupByDate(1L, 1L, saved3.getId(), 20);
+
+//        for (ChatMessageDateGroup dto:
+//             groupByDate) {
+//            System.out.println(dto.getDate() + " " + dto.getChats().stream().map(ChatMessage::getTimestamp).toList());
+//        }
     }
 }


### PR DESCRIPTION
## API 수정
- size를 클라이언트가 아닌 서버에게 책임을 맡기도록 수정
- 채팅 목록 조회자 정보 추가
## 응답 데이터 구조 변경
- 날짜 별로 채팅 목록을 묶어서 전달 날짜도 내림차 순, 묶인 날짜 안에서도 내림차 시간 순으로 정렬되어서 전달하도록 수정
- 전송 상태 FAIL/SUCCESS에 따른 쿼리 조건 추가 (조회자 본인 데이터라면 SUCCESS/FAILE 데이터 모두 조회, 다른 유저 데이터라면 SUCCESS만 조회하게끔 조건 추가