### PR TITLE
feat: implement re-send message api with failure

### DIFF
--- a/src/main/java/com/sottie/sottiechat/config/InMemorySessionRegistry.java
+++ b/src/main/java/com/sottie/sottiechat/config/InMemorySessionRegistry.java
@@ -1,6 +1,7 @@
 package com.sottie.sottiechat.config;
 
 import com.sottie.sottiechat.dto.SessionMeta;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -13,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Chat Room Session Management Registry In Memory
  */
 @Component
+@Slf4j
 public class InMemorySessionRegistry implements SessionRegistry {
 
     /*
@@ -29,6 +31,7 @@ public class InMemorySessionRegistry implements SessionRegistry {
     @Override
     public void addSession(Long roomId, Long userId, String sessionId) {
         if (isUserInRoom(roomId, userId)) {
+            log.info("[세션 등록] 이미 유저가 접속 중입니다.");
             throw new IllegalStateException("이미 채팅방에 접속 중인 유저입니다.");
         }
         roomUserSessionMap

--- a/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
+++ b/src/main/java/com/sottie/sottiechat/controller/ChatApiController.java
@@ -2,8 +2,10 @@ package com.sottie.sottiechat.controller;
 
 import com.sottie.sottiechat.domain.LastReadStatus;
 import com.sottie.sottiechat.dto.ChatMessageDateGroup;
+import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.service.MediaService;
 import com.sottie.sottiechat.service.MessageQueryService;
+import com.sottie.sottiechat.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatApiController {
     private final MessageQueryService messageQueryService;
+    private final MessageService messageService;
     private final MediaService mediaService;
 
     @GetMapping("/api/chat/{roomId}")
@@ -43,6 +46,16 @@ public class ChatApiController {
             @RequestPart(value = "files") List<MultipartFile> files
     ) {
         mediaService.uploadMediaFiles(roomId, userId, files);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/api/chat/{roomId}/resend/{userId}")
+    public ResponseEntity<Void> resendFailureMessage(
+            @PathVariable("roomId") Long roomId,
+            @PathVariable("userId") Long userId,
+            @RequestBody MessageRequest.Resend resend
+    ) {
+        messageService.resendFailureMessage(roomId, userId, resend);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sottie/sottiechat/domain/ResendType.java
+++ b/src/main/java/com/sottie/sottiechat/domain/ResendType.java
@@ -1,0 +1,6 @@
+package com.sottie.sottiechat.domain;
+
+public enum ResendType {
+    RESEND,
+    CANCEL
+}

--- a/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
+++ b/src/main/java/com/sottie/sottiechat/dto/MessageRequest.java
@@ -2,6 +2,7 @@ package com.sottie.sottiechat.dto;
 
 import com.sottie.sottiechat.domain.EventType;
 import com.sottie.sottiechat.domain.MessageType;
+import com.sottie.sottiechat.domain.ResendType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,5 +28,14 @@ public class MessageRequest {
     public static class LastRead {
         private Long userId;
         private String messageId;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Resend {
+        private String messageId;
+        private ResendType resendType;
     }
 }

--- a/src/main/java/com/sottie/sottiechat/service/MessageService.java
+++ b/src/main/java/com/sottie/sottiechat/service/MessageService.java
@@ -67,6 +67,28 @@ public class MessageService {
                 .build()), CHAT_ROUTING_KEY, SEND_MESSAGE);
     }
 
+    public void resendFailureMessage(Long roomId, Long userId, MessageRequest.Resend resend) {
+        if (!deleteMessage(roomId, userId, resend.getMessageId())) {
+            throw new IllegalStateException("메시지 삭제에 실패했습니다.");
+        }
+
+        if (resend.getResendType() == ResendType.RESEND) { // 재전송이라면 메시지 새롭게 저장 및 propagation
+            ChatMessage message = messageQueryService.getMessage(resend.getMessageId());
+
+            MessageResponse.Chat response = MessageResponse.Chat.from(userId, message.getContents(), EventType.CHAT);
+            propagateMessageToSubs(roomId, response, CHAT_ROUTING_KEY, SEND_MESSAGE);
+        }
+    }
+
+    public boolean deleteMessage(Long roomId, Long userId, String messageId) {
+        Query query = new Query(Criteria
+                .where("roomId").is(roomId)
+                .and("userId").is(userId)
+                .and("_id").is(messageId)
+                .and("status").is("FAIL"));
+        return mongoTemplate.remove(query, ChatMessage.class).getDeletedCount() > 0;
+    }
+
     public void updateLastReadStatus(Long roomId, MessageRequest.LastRead lastRead) {
         // 채팅방 접속하는 경우, 최신 채팅 조회
         if (lastRead.getMessageId() == null) {

--- a/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
+++ b/src/test/java/com/sottie/sottiechat/domain/ChatMessageTest.java
@@ -1,8 +1,10 @@
 package com.sottie.sottiechat.domain;
 
 import com.sottie.sottiechat.dto.ChatMessageDateGroup;
+import com.sottie.sottiechat.dto.MessageRequest;
 import com.sottie.sottiechat.repository.ChatMessageRepository;
 import com.sottie.sottiechat.service.MessageQueryService;
+import com.sottie.sottiechat.service.MessageService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,8 @@ class ChatMessageTest {
     ChatMessageRepository chatMessageRepository;
     @Autowired
     MessageQueryService messageQueryService;
+    @Autowired
+    MessageService messageService;
 
     @AfterEach
     void clean() {
@@ -111,5 +115,62 @@ class ChatMessageTest {
 //             groupByDate) {
 //            System.out.println(dto.getDate() + " " + dto.getChats().stream().map(ChatMessage::getTimestamp).toList());
 //        }
+    }
+
+    @Test
+    void resendTest() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId(1L)
+                .userId(1L)
+                .contents("Hello World")
+                .messageType(MessageType.TEXT)
+                .eventType(EventType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 26, 14, 0))
+                .status(Status.FAIL)
+                .build();
+        ChatMessage message4 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(1L)
+                .contents("Hello World4")
+                .messageType(MessageType.TEXT)
+                .eventType(EventType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 25, 14, 0))
+                .status(Status.SUCCESS)
+                .build();
+        ChatMessage message2 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(2L)
+                .contents("Hello World2")
+                .messageType(MessageType.TEXT)
+                .eventType(EventType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 26, 14, 2))
+                .status(Status.SUCCESS)
+                .build();
+        ChatMessage message3 = ChatMessage.builder()
+                .roomId(1L)
+                .userId(2L)
+                .contents("Hello World3")
+                .messageType(MessageType.TEXT)
+                .eventType(EventType.CHAT)
+                .timestamp(LocalDateTime.of(2025, 3, 27, 14, 0))
+                .status(Status.FAIL)
+                .build();
+        ChatMessage message5 = ChatMessage.builder()
+                .roomId(2L)
+                .userId(3L)
+                .contents("Hello World5")
+                .eventType(EventType.CHAT)
+                .messageType(MessageType.TEXT)
+                .timestamp(LocalDateTime.of(2025, 3, 27, 14, 1))
+                .status(Status.FAIL)
+                .build();
+
+        ChatMessage saved = chatMessageRepository.save(message);
+        ChatMessage saved2 = chatMessageRepository.save(message2);
+        ChatMessage saved3 = chatMessageRepository.save(message3);
+        ChatMessage saved4 = chatMessageRepository.save(message4);
+        ChatMessage saved5 = chatMessageRepository.save(message5);
+
+        messageService.resendFailureMessage(1L, 1L, MessageRequest.Resend.builder().messageId(message.getId()).resendType(ResendType.RESEND).build());
     }
 }


### PR DESCRIPTION
## 채팅 실패 메시지 재전송 API 구현
- 채팅 전송 실패 시 경우
1. 클라이언트 측 문제로 인해 실패한 경우
서버에 조차 전달되지 않았기에 DB에도 저장이 되어있지 않음. 
- 실패한 메시지를 로컬에 저장 후, 재전송/취소 판단하게 함.
  - 재전송: 실패한 메시지 그 포맷 그대로 일반 메시지 전송과 동일하게 send() 호출 (클라이언트 side)
  - 취소: 로컬에서 삭제만 하면 될듯 (클라이언트 side)
2. 서버 측 문제로 인해 실패한 경우
서버에 전달은 되었으나, 어떤 에러나 예외로 인해 FAIL 상태로 DB에 저장된 상태
- 전송자 본인한테만 실패한 메시지를 보여주게 하고, 이 메시지 자체에도 재전송/취소 판단하게 함.
  - 재전송: 기존 실패한 메시지를 삭제하고, 포맷 그대로 새로운 메시지로 생성 또는 기존 실패한 메시지에 시간과 상태만 업데이트
  - 취소: 실패한 메시지만 DB에서 삭제

- 1번의 경우 서버에서 특별히 처리할 것이 없기 때문에 2번 케이스에 대한 부분을 구현.
- 특히 재전송의 경우에는 전자 방식(기존 실패한 메시지 삭제, 그리고 포맷 그대로 새로운 메시지 생성)을 채택하여 구현
- 삭제의 경우 오직 FAIL인 메시지여야 가능하고, 본인 채팅방, 본인 메시지여야만 삭제 가능하게끔.